### PR TITLE
Support Rails 5.1

### DIFF
--- a/lib/lumber/inheritance_registry.rb
+++ b/lib/lumber/inheritance_registry.rb
@@ -57,6 +57,11 @@ module Lumber
         Object.class_eval do
 
           class << self
+            alias_method :inherited_without_lumber_registry, :inherited
+
+            def inherited(subclass)
+              inherited_with_lumber_registry(subclass)
+            end
 
             def inherited_with_lumber_registry(subclass)
               inherited_without_lumber_registry(subclass)
@@ -69,8 +74,6 @@ module Lumber
                 subclass.send(:include, Lumber.logger_concern)
               end
             end
-
-            alias_method_chain :inherited, :lumber_registry
 
           end
 

--- a/spec/inheritance_registry_spec.rb
+++ b/spec/inheritance_registry_spec.rb
@@ -83,7 +83,6 @@ describe Lumber::InheritanceRegistry do
     end
 
     it "doesn't add an inheritance handler multiple times" do
-      Object.singleton_class.should_receive(:alias_method_chain).once.and_call_original
       defined?(Object.inherited_with_lumber_registry).should be_falsey
       InheritanceRegistry.register_inheritance_handler
       defined?(Object.inherited_with_lumber_registry).should be_truthy


### PR DESCRIPTION
Remove usage of `alias_method_chain` aiming Rails 5.1 support.